### PR TITLE
Possible fix for COUNTER duplicate accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ The application build is handled by [Angular CLI](https://cli.angular.io/), refe
  
 All hosted versions of the Digital Archive API require authentication and are inaccessible to a locally hosted client, therefore the default development configuration requires the API to be locally hosted at https://localhost:44303/api. This is the default debug/development configuration for the .NET API.
 
+There are two primary configuration environments as follows:
+
+| Environment | Build Command                         | Build Target       | Client URL                               | Configured serviceBase      | Configured mediaBase                                     |
+|:------------|:--------------------------------------|:-------------------|:-----------------------------------------|:----------------------------|:---------------------------------------------------------|
+| (default)   | `ng serve`                            | (development)      | http://localhost:4200/                   | https://localhost:44303/api | https://daproductionstorage.blob.core.windows.net/media/ |
+| production  | `ng build --configuration=production` | sm-production-www  | https://sm.thehistorymakers.org          | api/                        | https://daproductionstorage.blob.core.windows.net/media/ |
+
 ### Deploying to Azure
 
 **NOTES**
@@ -23,7 +30,7 @@ All hosted versions of the Digital Archive API require authentication and are in
 2) For authentication to work properly, the Angular application must be bundled and deployed together with the .NET API.
 This .NET API should be locked down to "ScienceMakers only" for this ScienceMakers Digital Archive.
 3) Deployment is handled by Visual Studio 2019, refer to the digital-archive-api documentation for publishing specifics.
-```
+
 ## Browsers
 
 ### Tested

--- a/package-lock.json
+++ b/package-lock.json
@@ -710,12 +710,6 @@
       "resolved": "https://registry.npmjs.org/@angular/router/-/router-9.1.4.tgz",
       "integrity": "sha512-yUyjCgG2P2Jh8MvoyC6yirmAtx1Qe7MKLuLvsa9WOB571QNEcNLTYMfAMHUKsQTcE/+o984QyLlneoibgI9wFA=="
     },
-    "@angularclass/hmr": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@angularclass/hmr/-/hmr-1.2.2.tgz",
-      "integrity": "sha1-RqGPiaHpTQXCaLg8lIDgBfc/wmU=",
-      "dev": true
-    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -57,7 +57,7 @@ export class HomeComponent extends BaseComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.titleManagerService.setTitle("ScienceMakers Digital Archive (January 7, 2021)");
+        this.titleManagerService.setTitle("ScienceMakers Digital Archive (January 21, 2021)");
         this.liveAnnouncer.announce("ScienceMakers Digital Archive"); // NOTE: using LiveAnnouncer to eliminate possible double-speak
 
         this.historyMakerService.getCorpusSpecifics().pipe(takeUntil(this.ngUnsubscribe))

--- a/src/index-files/development/index.html
+++ b/src/index-files/development/index.html
@@ -61,7 +61,7 @@
           // (do not show in log for now...) console.log("fyi, aid and aname and publisher_reference: " + token.account_id + ", " + token.account_name + ", " + token.publisher_reference);
           _ll.push(['setDefaults', {
               pid: token.publisher_id,
-              aid: token.account_id,
+              aid: token.publisher_reference,
               aname: token.account_name,
               sid: token.session_id
           }]);

--- a/src/index-files/production/index.html
+++ b/src/index-files/production/index.html
@@ -73,7 +73,7 @@
           // (do not show in log for now...) console.log("fyi, aid and aname and publisher_reference: " + token.account_id + ", " + token.account_name + ", " + token.publisher_reference);
           _ll.push(['setDefaults', {
               pid: token.publisher_id,
-              aid: token.account_id,
+              aid: token.publisher_reference,
               aname: token.account_name,
               sid: token.session_id
           }]);

--- a/src/index-files/staging/index.html
+++ b/src/index-files/staging/index.html
@@ -73,7 +73,7 @@
           // (do not show in log for now...) console.log("fyi, aid and aname and publisher_reference: " + token.account_id + ", " + token.account_name + ", " + token.publisher_reference);
           _ll.push(['setDefaults', {
               pid: token.publisher_id,
-              aid: token.account_id,
+              aid: token.publisher_reference,
               aname: token.account_name,
               sid: token.session_id
           }]);


### PR DESCRIPTION
Submitting the incorrect value for aid causes LibLynx to generate
a new account on the fly to hold the reported COUNTER events